### PR TITLE
Fix the `OSError: [Errno 30] Read-only file system` problem in newer versions of Anki

### DIFF
--- a/addons21/fastwq/context.py
+++ b/addons21/fastwq/context.py
@@ -158,5 +158,7 @@ mediaPath = os.path.join(wp, "collection.media")
 os.chdir(mediaPath)
 config = Config(mw)
 # credit to https://github.com/AnkiStudio, https://github.com/sth2018/FastWordQuery/issues/259
-# fix the `OSError: [Errno 30] Read-only file system: '_fastwqcfg.json'` problem when modifying the configurations
+# fix the `OSError: [Errno 30] Read-only file system: '_fastwqcfg.json'` problem
+# when modifying the configurations in newer versions of Anki
 # by changing the root to a path with w permission
+# tested on MacBook Pro M1 Ventura 13

--- a/addons21/fastwq/context.py
+++ b/addons21/fastwq/context.py
@@ -153,4 +153,10 @@ class Config(object):
         return tmpstr
 
 
+wp = mw.pm.profileFolder()
+mediaPath = os.path.join(wp, "collection.media")
+os.chdir(mediaPath)
 config = Config(mw)
+# credit to https://github.com/AnkiStudio, https://github.com/sth2018/FastWordQuery/issues/259
+# fix the `OSError: [Errno 30] Read-only file system: '_fastwqcfg.json'` problem when modifying the configurations
+# by changing the root to a path with w permission


### PR DESCRIPTION
> credit to https://github.com/AnkiStudio, https://github.com/sth2018/FastWordQuery/issues/259

Fix the `OSError: [Errno 30] Read-only file system: '_fastwqcfg.json'` problem, when modifying the configurations in newer versions of Anki, by changing the root to a path with w permission.

Tested on MacBook Pro M1 Ventura 13